### PR TITLE
Update action with field for regex flags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Description regex to match'
     required: true
     default: '.*SUMMARY:.*'
+  description-regex-flags:
+    description: 'Flags for the description regex'
+    required: false
+    default: 'i'
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   description-regex-flags:
     description: 'Flags for the description regex'
     required: false
-    default: 'i'
+    default: ''
 runs:
   using: 'node12'
   main: 'lib/main.js'


### PR DESCRIPTION
The field was used in the main.ts, but not defined in the workflow action. This attempts to fix it to get rid of the validation warning in GitHub.